### PR TITLE
set MaxFeePerGas for debug_traceCall to support Erigon

### DIFF
--- a/pkg/entrypoint/execution/trace.go
+++ b/pkg/entrypoint/execution/trace.go
@@ -47,6 +47,12 @@ func TraceSimulateHandleOp(
 		To:   entryPoint,
 		Data: tx.Data(),
 	}
+
+	if op.MaxFeePerGas != nil {
+		var maxFeePerGas = hexutil.Big(*op.MaxFeePerGas)
+		req.MaxFeePerGas = &maxFeePerGas
+	}
+
 	opts := utils.TraceCallOpts{
 		Tracer: customTracer,
 	}

--- a/pkg/entrypoint/simulation/tracevalidation.go
+++ b/pkg/entrypoint/simulation/tracevalidation.go
@@ -10,6 +10,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stackup-wallet/stackup-bundler/pkg/entrypoint"
@@ -50,6 +51,12 @@ func TraceSimulateValidation(
 		To:   entryPoint,
 		Data: tx.Data(),
 	}
+
+	if op.MaxFeePerGas != nil {
+		var maxFeePerGas = hexutil.Big(*op.MaxFeePerGas)
+		req.MaxFeePerGas = &maxFeePerGas
+	}
+
 	opts := utils.TraceCallOpts{
 		Tracer: customTracer,
 	}

--- a/pkg/entrypoint/utils/tracing.go
+++ b/pkg/entrypoint/utils/tracing.go
@@ -7,9 +7,10 @@ import (
 )
 
 type TraceCallReq struct {
-	From common.Address `json:"from"`
-	To   common.Address `json:"to"`
-	Data hexutil.Bytes  `json:"data"`
+	From         common.Address `json:"from"`
+	To           common.Address `json:"to"`
+	Data         hexutil.Bytes  `json:"data"`
+	MaxFeePerGas *hexutil.Big   `json:"maxFeePerGas,omitempty"`
 }
 
 type TraceCallOpts struct {


### PR DESCRIPTION
Currently, Erigon and Geth have slightly different behavior for `debug_traceCall`. Erigon requires the gas price to be set, as noted in this Github issue https://github.com/ledgerwatch/erigon/issues/3494. 

This PR sets the price for `debug_traceCall` calls, taking MaxFeePerGas from userop.UserOperation. With this patch, the Stackup bundler now works with the Erigon client as well. 