### PR TITLE
jsonrpc string id

### DIFF
--- a/pkg/jsonrpc/handler.go
+++ b/pkg/jsonrpc/handler.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-func jsonrpcError(c *gin.Context, code int, message string, data any, id *float64) {
+func jsonrpcError(c *gin.Context, code int, message string, data any, id any) {
 	c.JSON(http.StatusOK, gin.H{
 		"jsonrpc": "2.0",
 		"error": gin.H{
@@ -58,10 +58,14 @@ func Controller(api interface{}) gin.HandlerFunc {
 			return
 		}
 
+		var id any
 		id, ok := data["id"].(float64)
 		if !ok {
-			jsonrpcError(c, -32600, "Invalid Request", "No or invalid 'id' in request", nil)
-			return
+			id, ok = data["id"].(string)
+			if !ok {
+				jsonrpcError(c, -32600, "Invalid Request", "No or invalid 'id' in request", nil)
+				return
+			}
 		}
 
 		if data["jsonrpc"] != "2.0" {


### PR DESCRIPTION
jsonrpc requests with string id

For example :
`{
    "jsonrpc": "2.0",
    "id": "x-reqid-1",
    "method": "eth_supportedEntryPoints",
    "params": []
}`

Now return:
`{
    "error": {
        "code": -32600,
        "data": "No or invalid 'id' in request",
        "message": "Invalid Request"
    },
    "id": null,
    "jsonrpc": "2.0"
}`

Fixed:
`{
    "id": "x-reqid-1",
    "jsonrpc": "2.0",
    "result": [
        "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
    ]
}`
