### PR TITLE
eth_getUserOperationBySender

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	getUserOpReceipt     GetUserOpReceiptFunc
 	getGasEstimate       GetGasEstimateFunc
 	getUserOpByHash      GetUserOpByHashFunc
+	getUserOpBySender    GetUserOpBySenderFunc
 }
 
 // New initializes a new ERC-4337 client which can be extended with modules for validating UserOperations
@@ -49,6 +50,7 @@ func New(
 		getUserOpReceipt:     getUserOpReceiptNoop(),
 		getGasEstimate:       getGasEstimateNoop(),
 		getUserOpByHash:      getUserOpByHashNoop(),
+		getUserOpBySender:    getUserOpBySenderNoop(),
 	}
 }
 
@@ -212,6 +214,21 @@ func (i *Client) GetUserOperationByHash(hash string) (*filter.HashLookupResult, 
 	l := i.logger.WithName("eth_getUserOperationByHash").WithValues("userop_hash", hash)
 
 	res, err := i.getUserOpByHash(hash, i.supportedEntryPoints[0], i.chainID)
+	if err != nil {
+		l.Error(err, "eth_getUserOperationByHash error")
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// GetUserOperationBySender returns a UserOperation based on a given sender returned by
+// *Client.SendUserOperation.
+func (i *Client) GetUserOperationBySender(sender string) (*filter.SenderLookupResult, error) {
+	// Init logger
+	l := i.logger.WithName("eth_getUserOperationBySender").WithValues("sender", sender)
+
+	res, err := i.getUserOpBySender(sender, i.supportedEntryPoints[0], i.chainID)
 	if err != nil {
 		l.Error(err, "eth_getUserOperationByHash error")
 		return nil, err

--- a/pkg/client/rpc.go
+++ b/pkg/client/rpc.go
@@ -42,6 +42,13 @@ func (r *RpcAdapter) Eth_getUserOperationByHash(
 	return r.client.GetUserOperationByHash(userOpHash)
 }
 
+// Eth_getUserOperationBySender routes method calls to *Client.GetUserOperationBySender.
+func (r *RpcAdapter) Eth_getUserOperationBySender(
+	sender string,
+) (*filter.SenderLookupResult, error) {
+	return r.client.GetUserOperationBySender(sender)
+}
+
 // Eth_supportedEntryPoints routes method calls to *Client.SupportedEntryPoints.
 func (r *RpcAdapter) Eth_supportedEntryPoints() ([]string, error) {
 	return r.client.SupportedEntryPoints()

--- a/pkg/client/utils.go
+++ b/pkg/client/utils.go
@@ -73,3 +73,22 @@ func GetUserOpByHashWithEthClient(eth *ethclient.Client) GetUserOpByHashFunc {
 		return filter.GetUserOperationByHash(eth, hash, ep, chain)
 	}
 }
+
+// GetUserOpBySenderFunc is a general interface for fetching a UserOperation given a sender, EntryPoint
+// address, and chain ID.
+type GetUserOpBySenderFunc func(sender string, ep common.Address, chain *big.Int) (*filter.SenderLookupResult, error)
+
+func getUserOpBySenderNoop() GetUserOpBySenderFunc {
+	return func(sender string, ep common.Address, chain *big.Int) (*filter.SenderLookupResult, error) {
+		//lint:ignore ST1005 This needs to match the bundler test spec.
+		return nil, errors.New("Missing/invalid sender")
+	}
+}
+
+// GetUserOpBySenderWithEthClient returns an implementation of GetUserOpBySenderFunc that relies on an eth client
+// to fetch a UserOperation.
+func GetUserOpBySenderWithEthClient(eth *ethclient.Client) GetUserOpBySenderFunc {
+	return func(sender string, ep common.Address, chain *big.Int) (*filter.SenderLookupResult, error) {
+		return filter.GetUserOperationBySender(eth, common.HexToAddress(sender), ep, chain)
+	}
+}

--- a/pkg/entrypoint/filter/event.go
+++ b/pkg/entrypoint/filter/event.go
@@ -37,3 +37,31 @@ func filterUserOperationEvent(
 		[]common.Address{},
 	)
 }
+
+func filterUserOperationSenderEvent(
+	eth *ethclient.Client,
+	sender,
+	entryPoint common.Address,
+) (*entrypoint.EntrypointUserOperationEventIterator, error) {
+	ep, err := entrypoint.NewEntrypoint(entryPoint, eth)
+	if err != nil {
+		return nil, err
+	}
+	bn, err := eth.BlockNumber(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	toBlk := big.NewInt(0).SetUint64(bn)
+	startBlk := big.NewInt(0)
+	sub10kBlk := big.NewInt(0).Sub(toBlk, big.NewInt(10000))
+	if sub10kBlk.Cmp(startBlk) > 0 {
+		startBlk = sub10kBlk
+	}
+
+	return ep.FilterUserOperationEvent(
+		&bind.FilterOpts{Start: startBlk.Uint64()},
+		[][32]byte{},
+		[]common.Address{sender},
+		[]common.Address{},
+	)
+}

--- a/pkg/entrypoint/filter/opbyhash.go
+++ b/pkg/entrypoint/filter/opbyhash.go
@@ -21,6 +21,7 @@ type HashLookupResult struct {
 	BlockNumber     *big.Int              `json:"blockNumber"`
 	BlockHash       common.Hash           `json:"blockHash"`
 	TransactionHash common.Hash           `json:"transactionHash"`
+	IsPending       bool                  `json:"isPending"`
 }
 
 // GetUserOperationByHash filters the EntryPoint contract for UserOperationEvents and returns the
@@ -44,9 +45,6 @@ func GetUserOperationByHash(
 		tx, isPending, err := eth.TransactionByHash(context.Background(), it.Event.Raw.TxHash)
 		if err != nil {
 			return nil, err
-		} else if isPending {
-			//lint:ignore ST1005 This needs to match the bundler test spec.
-			return nil, errors.New("Missing/invalid userOpHash")
 		}
 
 		hex := hexutil.Encode(tx.Data())
@@ -99,6 +97,7 @@ func GetUserOperationByHash(
 						BlockNumber:     receipt.BlockNumber,
 						BlockHash:       receipt.BlockHash,
 						TransactionHash: it.Event.Raw.TxHash,
+						IsPending:       isPending,
 					}, nil
 				}
 			}

--- a/pkg/entrypoint/filter/opbysender.go
+++ b/pkg/entrypoint/filter/opbysender.go
@@ -1,0 +1,110 @@
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stackup-wallet/stackup-bundler/pkg/entrypoint/methods"
+	"github.com/stackup-wallet/stackup-bundler/pkg/userop"
+)
+
+type SenderLookupResult struct {
+	UserOperation   *userop.UserOperation `json:"userOperation"`
+	EntryPoint      string                `json:"entryPoint"`
+	BlockNumber     *big.Int              `json:"blockNumber"`
+	BlockHash       common.Hash           `json:"blockHash"`
+	TransactionHash common.Hash           `json:"transactionHash"`
+	IsPending       bool                  `json:"isPending"`
+}
+
+// GetUserOperationBySender filters the EntryPoint contract for UserOperationEvents and returns the
+// corresponding UserOp from a given sender.
+func GetUserOperationBySender(
+	eth *ethclient.Client,
+	sender,
+	entryPoint common.Address,
+	chainID *big.Int,
+) (*SenderLookupResult, error) {
+	it, err := filterUserOperationSenderEvent(eth, sender, entryPoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if it.Next() {
+		receipt, err := eth.TransactionReceipt(context.Background(), it.Event.Raw.TxHash)
+		if err != nil {
+			return nil, err
+		}
+		tx, isPending, err := eth.TransactionByHash(context.Background(), it.Event.Raw.TxHash)
+		if err != nil {
+			return nil, err
+		}
+
+		hex := hexutil.Encode(tx.Data())
+		if strings.HasPrefix(hex, methods.HandleOpsSelector) {
+			data := common.Hex2Bytes(hex[len(methods.HandleOpsSelector):])
+			args, err := methods.HandleOpsMethod.Inputs.Unpack(data)
+			if err != nil {
+				return nil, err
+			}
+			if len(args) != 2 {
+				return nil, fmt.Errorf(
+					"handleOps: invalid input length: expected 2, got %d",
+					len(args),
+				)
+			}
+
+			// TODO: Find better way to convert this
+			ops, ok := args[0].([]struct {
+				Sender               common.Address `json:"sender"`
+				Nonce                *big.Int       `json:"nonce"`
+				InitCode             []uint8        `json:"initCode"`
+				CallData             []uint8        `json:"callData"`
+				CallGasLimit         *big.Int       `json:"callGasLimit"`
+				VerificationGasLimit *big.Int       `json:"verificationGasLimit"`
+				PreVerificationGas   *big.Int       `json:"preVerificationGas"`
+				MaxFeePerGas         *big.Int       `json:"maxFeePerGas"`
+				MaxPriorityFeePerGas *big.Int       `json:"maxPriorityFeePerGas"`
+				PaymasterAndData     []uint8        `json:"paymasterAndData"`
+				Signature            []uint8        `json:"signature"`
+			})
+			if !ok {
+				return nil, errors.New("handleOps: cannot assert type: ops is not of type []struct{...}")
+			}
+
+			for _, abiOp := range ops {
+				data, err := json.Marshal(abiOp)
+				if err != nil {
+					return nil, err
+				}
+
+				var op userop.UserOperation
+				if err = json.Unmarshal(data, &op); err != nil {
+					return nil, err
+				}
+
+				if op.Sender == sender {
+					return &SenderLookupResult{
+						UserOperation:   &op,
+						EntryPoint:      entryPoint.String(),
+						BlockNumber:     receipt.BlockNumber,
+						BlockHash:       receipt.BlockHash,
+						TransactionHash: it.Event.Raw.TxHash,
+						IsPending:       isPending,
+					}, nil
+				}
+			}
+		}
+
+	}
+
+	//lint:ignore ST1005 This needs to match the bundler test spec.
+	return nil, errors.New("Missing/invalid userOpHash")
+}


### PR DESCRIPTION
### Some context

This is the scenario:
1. I submit a user op
2. The request to “eth_sendUserOperation” succeeds
3. An arbitrary amount of time passes
4. It gets included on-chain

During step 3 is where it’s challenging to create a reliable user experience.

In certain scenarios I need to be able to identify that there is a pending userop in the mempool for a given sender. The only way right now, is to try and submit a user op to see if I get the “pending user ops” message. 

It would make a big difference to have a way to return a pending user op by sender “eth_getUserOperationBySender”.  And also exposing pending ops.

That way we can avoid overwriting a pending user op by accident with a new one and implement retry logic with +10% gas fee bumps properly. We could also re-submit with batch execute instead.

### The PR

RPC method to return user operations based on a sender. Since these are indexed, it should not be too much of an issue to expose.

I also exposed pending operations with an extra bool in the return struct `isPending`. 

Hopefully this makes sense and is the right way to submit a PR to this repository.