### PR TITLE
Add support for Erigon client

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install Geth
         run: |
-          wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.12.2-bed84606.tar.gz
+          wget -P ./standalone-bundle https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.12.2-bed84606.tar.gz && \
           tar -xvf geth-linux-amd64-1.12.2-bed84606.tar.gz -C ./standalone-bundle
 
       - name: Run Geth

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Install Geth
         run: |
-          wget -P ./standalone-bundle https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.12.2-bed84606.tar.gz && \
+          wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.12.2-bed84606.tar.gz && \
+          mkdir standalone-bundle && \
           tar -xvf geth-linux-amd64-1.12.2-bed84606.tar.gz -C ./standalone-bundle
 
       - name: Run Geth

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -83,7 +83,8 @@ jobs:
 
       - name: Fund bundler
         run: |
-          geth \
+          cd geth-linux-amd64-1.12.2-bed84606 && \
+          ./geth \
           --exec "eth.sendTransaction({from: eth.accounts[0], to: \"0x43378ff8C70109Ee4Dbe85aF34428ab0615EBd23\", value: web3.toWei(10000, \"ether\")})" \
           attach http://localhost:8545/
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -50,12 +50,13 @@ jobs:
       - name: Install Geth
         run: |
           wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.12.2-bed84606.tar.gz && \
-          mkdir standalone-bundle && \
-          tar -xvf geth-linux-amd64-1.12.2-bed84606.tar.gz -C ./standalone-bundle
+          mkdir standalone-geth && \
+          tar -xvf geth-linux-amd64-1.12.2-bed84606.tar.gz -C ./standalone-geth
 
       - name: Run Geth
+        working-directory: ./standalone-geth
         run: |
-          ./standalone-bundle/geth \
+          ./geth \
           --verbosity 1 \
           --http.vhosts '*,localhost,host.docker.internal' \
           --http \

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run Geth
         run: |
-          cd geth-linux-amd64-1.12.2-bed84606 &&
+          cd geth-linux-amd64-1.12.2-bed84606 && \
           ./geth \
           --verbosity 1 \
           --http.vhosts '*,localhost,host.docker.internal' \

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:ethereum/ethereum && \
           sudo apt-get update && \
-          sudo apt-get install ethereum
+          sudo apt-get install ethereum=1.12.2
 
       - name: Run Geth
         run: |

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -50,12 +50,11 @@ jobs:
       - name: Install Geth
         run: |
           wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.12.2-bed84606.tar.gz && \
-          mkdir standalone-geth && \
-          tar -xvf geth-linux-amd64-1.12.2-bed84606.tar.gz -C ./standalone-geth
+          tar -xvf geth-linux-amd64-1.12.2-bed84606.tar.gz
 
       - name: Run Geth
-        working-directory: ./standalone-geth
         run: |
+          cd geth-linux-amd64-1.12.2-bed84606 &&
           ./geth \
           --verbosity 1 \
           --http.vhosts '*,localhost,host.docker.internal' \

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -49,13 +49,12 @@ jobs:
 
       - name: Install Geth
         run: |
-          sudo add-apt-repository -y ppa:ethereum/ethereum && \
-          sudo apt-get update && \
-          sudo apt-get install ethereum=1.12.2
+          wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.12.2-bed84606.tar.gz
+          tar -xvf geth-linux-amd64-1.12.2-bed84606.tar.gz -C ./standalone-bundle
 
       - name: Run Geth
         run: |
-          geth \
+          ./standalone-bundle/geth \
           --verbosity 1 \
           --http.vhosts '*,localhost,host.docker.internal' \
           --http \

--- a/pkg/entrypoint/execution/trace.go
+++ b/pkg/entrypoint/execution/trace.go
@@ -98,7 +98,7 @@ func TraceSimulateHandleOp(in *TraceInput) (*TraceOutput, error) {
 	}
 	opts := utils.TraceCallOpts{
 		Tracer:         tracer.Loaded.BundlerExecutionTracer,
-		StateOverrides: utils.DefaultOverrides,
+		StateOverrides: utils.DefaultStateOverrides,
 	}
 	if err := in.Rpc.CallContext(context.Background(), &res, "debug_traceCall", &req, "latest", &opts); err != nil {
 		return nil, err

--- a/pkg/entrypoint/execution/trace.go
+++ b/pkg/entrypoint/execution/trace.go
@@ -27,9 +27,9 @@ type TraceInput struct {
 	ChainID    *big.Int
 
 	// Optional params for simulateHandleOps
-	Target       common.Address
-	Data         []byte
-	TracerFeeCap *big.Int
+	Target      common.Address
+	Data        []byte
+	TraceFeeCap *big.Int
 }
 
 type TraceOutput struct {
@@ -80,8 +80,8 @@ func TraceSimulateHandleOp(in *TraceInput) (*TraceOutput, error) {
 	auth.GasLimit = math.MaxUint64
 	auth.NoSend = true
 	mf := in.Op.MaxFeePerGas
-	if in.TracerFeeCap != nil {
-		mf = in.TracerFeeCap
+	if in.TraceFeeCap != nil {
+		mf = in.TraceFeeCap
 	}
 	tx, err := ep.SimulateHandleOp(auth, entrypoint.UserOperation(*in.Op), in.Target, in.Data)
 	if err != nil {

--- a/pkg/entrypoint/execution/trace.go
+++ b/pkg/entrypoint/execution/trace.go
@@ -98,7 +98,7 @@ func TraceSimulateHandleOp(in *TraceInput) (*TraceOutput, error) {
 	}
 	opts := utils.TraceCallOpts{
 		Tracer:         tracer.Loaded.BundlerExecutionTracer,
-		StateOverrides: utils.DefaultOverride,
+		StateOverrides: utils.DefaultOverrides,
 	}
 	if err := in.Rpc.CallContext(context.Background(), &res, "debug_traceCall", &req, "latest", &opts); err != nil {
 		return nil, err

--- a/pkg/entrypoint/execution/trace.go
+++ b/pkg/entrypoint/execution/trace.go
@@ -94,10 +94,11 @@ func TraceSimulateHandleOp(in *TraceInput) (*TraceOutput, error) {
 		From:         common.HexToAddress("0x"),
 		To:           in.EntryPoint,
 		Data:         tx.Data(),
-		MaxFeePerGas: (*hexutil.Big)(mf),
+		MaxFeePerGas: hexutil.Big(*mf),
 	}
 	opts := utils.TraceCallOpts{
-		Tracer: tracer.Loaded.BundlerExecutionTracer,
+		Tracer:         tracer.Loaded.BundlerExecutionTracer,
+		StateOverrides: utils.DefaultOverride,
 	}
 	if err := in.Rpc.CallContext(context.Background(), &res, "debug_traceCall", &req, "latest", &opts); err != nil {
 		return nil, err

--- a/pkg/entrypoint/simulation/tracevalidation.go
+++ b/pkg/entrypoint/simulation/tracevalidation.go
@@ -53,7 +53,7 @@ func TraceSimulateValidation(
 	}
 	opts := utils.TraceCallOpts{
 		Tracer:         tracer.Loaded.BundlerCollectorTracer,
-		StateOverrides: utils.DefaultOverride,
+		StateOverrides: utils.DefaultOverrides,
 	}
 	if err := rpc.CallContext(context.Background(), &res, "debug_traceCall", &req, "latest", &opts); err != nil {
 		return nil, err

--- a/pkg/entrypoint/simulation/tracevalidation.go
+++ b/pkg/entrypoint/simulation/tracevalidation.go
@@ -52,7 +52,8 @@ func TraceSimulateValidation(
 		MaxFeePerGas: hexutil.Big(*op.MaxFeePerGas),
 	}
 	opts := utils.TraceCallOpts{
-		Tracer: tracer.Loaded.BundlerCollectorTracer,
+		Tracer:         tracer.Loaded.BundlerCollectorTracer,
+		StateOverrides: utils.DefaultOverride,
 	}
 	if err := rpc.CallContext(context.Background(), &res, "debug_traceCall", &req, "latest", &opts); err != nil {
 		return nil, err

--- a/pkg/entrypoint/simulation/tracevalidation.go
+++ b/pkg/entrypoint/simulation/tracevalidation.go
@@ -53,7 +53,7 @@ func TraceSimulateValidation(
 	}
 	opts := utils.TraceCallOpts{
 		Tracer:         tracer.Loaded.BundlerCollectorTracer,
-		StateOverrides: utils.DefaultOverrides,
+		StateOverrides: utils.DefaultStateOverrides,
 	}
 	if err := rpc.CallContext(context.Background(), &res, "debug_traceCall", &req, "latest", &opts); err != nil {
 		return nil, err

--- a/pkg/entrypoint/simulation/tracevalidation.go
+++ b/pkg/entrypoint/simulation/tracevalidation.go
@@ -10,6 +10,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stackup-wallet/stackup-bundler/pkg/entrypoint"
@@ -45,9 +46,10 @@ func TraceSimulateValidation(
 
 	var res tracer.BundlerCollectorReturn
 	req := utils.TraceCallReq{
-		From: common.HexToAddress("0x"),
-		To:   entryPoint,
-		Data: tx.Data(),
+		From:         common.HexToAddress("0x"),
+		To:           entryPoint,
+		Data:         tx.Data(),
+		MaxFeePerGas: (*hexutil.Big)(op.MaxFeePerGas),
 	}
 	opts := utils.TraceCallOpts{
 		Tracer: tracer.Loaded.BundlerCollectorTracer,

--- a/pkg/entrypoint/simulation/tracevalidation.go
+++ b/pkg/entrypoint/simulation/tracevalidation.go
@@ -49,7 +49,7 @@ func TraceSimulateValidation(
 		From:         common.HexToAddress("0x"),
 		To:           entryPoint,
 		Data:         tx.Data(),
-		MaxFeePerGas: (*hexutil.Big)(op.MaxFeePerGas),
+		MaxFeePerGas: hexutil.Big(*op.MaxFeePerGas),
 	}
 	opts := utils.TraceCallOpts{
 		Tracer: tracer.Loaded.BundlerCollectorTracer,

--- a/pkg/entrypoint/utils/tracing.go
+++ b/pkg/entrypoint/utils/tracing.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"math"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -10,14 +13,24 @@ type TraceCallReq struct {
 	From         common.Address `json:"from"`
 	To           common.Address `json:"to"`
 	Data         hexutil.Bytes  `json:"data"`
-	MaxFeePerGas *hexutil.Big   `json:"maxFeePerGas"`
+	MaxFeePerGas hexutil.Big    `json:"maxFeePerGas"`
+}
+
+type TracerStateOverrides struct {
+	Balance hexutil.Big `json:"balance"`
 }
 
 type TraceCallOpts struct {
-	Tracer string `json:"tracer"`
+	Tracer         string                          `json:"tracer"`
+	StateOverrides map[string]TracerStateOverrides `json:"stateOverrides"`
 }
 
 var (
 	// A dummy private key used to build *bind.TransactOpts for simulation.
 	DummyPk, _ = crypto.GenerateKey()
+
+	// A default state override to ensure the zero address always has sufficient funds.
+	DefaultOverride = map[string]TracerStateOverrides{
+		common.HexToAddress("0x").Hex(): {Balance: hexutil.Big(*big.NewInt(math.MaxInt64))},
+	}
 )

--- a/pkg/entrypoint/utils/tracing.go
+++ b/pkg/entrypoint/utils/tracing.go
@@ -7,9 +7,10 @@ import (
 )
 
 type TraceCallReq struct {
-	From common.Address `json:"from"`
-	To   common.Address `json:"to"`
-	Data hexutil.Bytes  `json:"data"`
+	From         common.Address `json:"from"`
+	To           common.Address `json:"to"`
+	Data         hexutil.Bytes  `json:"data"`
+	MaxFeePerGas *hexutil.Big   `json:"maxFeePerGas"`
 }
 
 type TraceCallOpts struct {

--- a/pkg/entrypoint/utils/tracing.go
+++ b/pkg/entrypoint/utils/tracing.go
@@ -31,6 +31,6 @@ var (
 
 	// A default state override to ensure the zero address always has sufficient funds.
 	DefaultOverride = map[string]TracerStateOverrides{
-		common.HexToAddress("0x").Hex(): {Balance: hexutil.Big(*big.NewInt(math.MaxInt64))},
+		common.HexToAddress("0x").Hex(): {Balance: hexutil.Big(*big.NewInt(0).SetUint64(math.MaxUint64))},
 	}
 )

--- a/pkg/entrypoint/utils/tracing.go
+++ b/pkg/entrypoint/utils/tracing.go
@@ -30,7 +30,7 @@ var (
 	DummyPk, _ = crypto.GenerateKey()
 
 	// A default state override to ensure the zero address always has sufficient funds.
-	DefaultOverride = map[string]TracerStateOverrides{
+	DefaultOverrides = map[string]TracerStateOverrides{
 		common.HexToAddress("0x").Hex(): {Balance: hexutil.Big(*big.NewInt(0).SetUint64(math.MaxUint64))},
 	}
 )

--- a/pkg/entrypoint/utils/tracing.go
+++ b/pkg/entrypoint/utils/tracing.go
@@ -16,13 +16,13 @@ type TraceCallReq struct {
 	MaxFeePerGas hexutil.Big    `json:"maxFeePerGas"`
 }
 
-type TracerStateOverrides struct {
+type TraceStateOverrides struct {
 	Balance hexutil.Big `json:"balance"`
 }
 
 type TraceCallOpts struct {
-	Tracer         string                          `json:"tracer"`
-	StateOverrides map[string]TracerStateOverrides `json:"stateOverrides"`
+	Tracer         string                         `json:"tracer"`
+	StateOverrides map[string]TraceStateOverrides `json:"stateOverrides"`
 }
 
 var (
@@ -30,7 +30,7 @@ var (
 	DummyPk, _ = crypto.GenerateKey()
 
 	// A default state override to ensure the zero address always has sufficient funds.
-	DefaultStateOverrides = map[string]TracerStateOverrides{
+	DefaultStateOverrides = map[string]TraceStateOverrides{
 		common.HexToAddress("0x").Hex(): {Balance: hexutil.Big(*big.NewInt(0).SetUint64(math.MaxUint64))},
 	}
 )

--- a/pkg/entrypoint/utils/tracing.go
+++ b/pkg/entrypoint/utils/tracing.go
@@ -30,7 +30,7 @@ var (
 	DummyPk, _ = crypto.GenerateKey()
 
 	// A default state override to ensure the zero address always has sufficient funds.
-	DefaultOverrides = map[string]TracerStateOverrides{
+	DefaultStateOverrides = map[string]TracerStateOverrides{
 		common.HexToAddress("0x").Hex(): {Balance: hexutil.Big(*big.NewInt(0).SetUint64(math.MaxUint64))},
 	}
 )

--- a/pkg/gas/estimate.go
+++ b/pkg/gas/estimate.go
@@ -131,10 +131,11 @@ func EstimateGas(in *EstimateInput) (verificationGas uint64, callGas uint64, err
 		return 0, 0, err
 	}
 	out, err := execution.TraceSimulateHandleOp(&execution.TraceInput{
-		Rpc:        in.Rpc,
-		EntryPoint: in.EntryPoint,
-		Op:         simOp,
-		ChainID:    in.ChainID,
+		Rpc:          in.Rpc,
+		EntryPoint:   in.EntryPoint,
+		Op:           simOp,
+		ChainID:      in.ChainID,
+		TracerFeeCap: in.Op.MaxFeePerGas,
 	})
 	if err != nil {
 		return 0, 0, err

--- a/pkg/gas/estimate.go
+++ b/pkg/gas/estimate.go
@@ -131,11 +131,11 @@ func EstimateGas(in *EstimateInput) (verificationGas uint64, callGas uint64, err
 		return 0, 0, err
 	}
 	out, err := execution.TraceSimulateHandleOp(&execution.TraceInput{
-		Rpc:          in.Rpc,
-		EntryPoint:   in.EntryPoint,
-		Op:           simOp,
-		ChainID:      in.ChainID,
-		TracerFeeCap: in.Op.MaxFeePerGas,
+		Rpc:         in.Rpc,
+		EntryPoint:  in.EntryPoint,
+		Op:          simOp,
+		ChainID:     in.ChainID,
+		TraceFeeCap: in.Op.MaxFeePerGas,
 	})
 	if err != nil {
 		return 0, 0, err


### PR DESCRIPTION
Erigon client requires fee cap to be explicitly set on `debug_traceCall`. We also need to add a state override to make sure the zero address has enough funds to execute at the fee cap.

closes #157 