### PR TITLE
Allow configuring MaxOpsForBatch

### DIFF
--- a/internal/config/values.go
+++ b/internal/config/values.go
@@ -24,6 +24,7 @@ type Values struct {
 	PMGasEstBuffer          int64
 	MaxOpTTL                time.Duration
 	MaxOpsForUnstakedSender int
+	MaxOpsForBundle         int
 	Beneficiary             string
 
 	// Searcher mode variables.
@@ -79,6 +80,7 @@ func GetValues() *Values {
 	viper.SetDefault("erc4337_bundler_paymaster_gas_estimate_buffer", 10)
 	viper.SetDefault("erc4337_bundler_max_op_ttl_seconds", 180)
 	viper.SetDefault("erc4337_bundler_max_ops_for_unstaked_sender", 4)
+	viper.SetDefault("erc4337_bundler_max_ops_for_bundle", 0)
 	viper.SetDefault("erc4337_bundler_blocks_in_the_future", 25)
 	viper.SetDefault("erc4337_bundler_otel_insecure_mode", false)
 	viper.SetDefault("erc4337_bundler_debug_mode", false)
@@ -109,6 +111,7 @@ func GetValues() *Values {
 	_ = viper.BindEnv("erc4337_bundler_paymaster_gas_estimate_buffer")
 	_ = viper.BindEnv("erc4337_bundler_max_op_ttl_seconds")
 	_ = viper.BindEnv("erc4337_bundler_max_ops_for_unstaked_sender")
+	_ = viper.BindEnv("erc4337_bundler_max_ops_for_bundle")
 	_ = viper.BindEnv("erc4337_bundler_eth_builder_url")
 	_ = viper.BindEnv("erc4337_bundler_blocks_in_the_future")
 	_ = viper.BindEnv("erc4337_bundler_otel_service_name")
@@ -160,6 +163,7 @@ func GetValues() *Values {
 	pmGasEstBuffer := int64(viper.GetInt("erc4337_bundler_paymaster_gas_estimate_buffer"))
 	maxOpTTL := time.Second * viper.GetDuration("erc4337_bundler_max_op_ttl_seconds")
 	maxOpsForUnstakedSender := viper.GetInt("erc4337_bundler_max_ops_for_unstaked_sender")
+	maxOpsForBundle := viper.GetInt("erc4337_bundler_max_ops_for_bundle")
 	ethBuilderUrl := viper.GetString("erc4337_bundler_eth_builder_url")
 	blocksInTheFuture := viper.GetInt("erc4337_bundler_blocks_in_the_future")
 	otelServiceName := viper.GetString("erc4337_bundler_otel_service_name")
@@ -180,6 +184,7 @@ func GetValues() *Values {
 		PMGasEstBuffer:          pmGasEstBuffer,
 		MaxOpTTL:                maxOpTTL,
 		MaxOpsForUnstakedSender: maxOpsForUnstakedSender,
+		MaxOpsForBundle:         maxOpsForBundle,
 		EthBuilderUrl:           ethBuilderUrl,
 		BlocksInTheFuture:       blocksInTheFuture,
 		OTELServiceName:         otelServiceName,

--- a/internal/start/private.go
+++ b/internal/start/private.go
@@ -134,6 +134,7 @@ func PrivateMode() {
 	b.SetGetBaseFeeFunc(gasprice.GetBaseFeeWithEthClient(eth))
 	b.SetGetGasTipFunc(gasprice.GetGasTipWithEthClient(eth))
 	b.SetGetLegacyGasPriceFunc(gasprice.GetLegacyGasPriceWithEthClient(eth))
+	b.SetMaxBatch(conf.MaxOpsForBundle)
 	b.UseLogger(logr)
 	if err := b.UserMeter(otel.GetMeterProvider().Meter("bundler")); err != nil {
 		log.Fatal(err)

--- a/internal/start/searcher.go
+++ b/internal/start/searcher.go
@@ -133,6 +133,7 @@ func SearcherMode() {
 	b.SetGetBaseFeeFunc(gasprice.GetBaseFeeWithEthClient(eth))
 	b.SetGetGasTipFunc(gasprice.GetGasTipWithEthClient(eth))
 	b.SetGetLegacyGasPriceFunc(gasprice.GetLegacyGasPriceWithEthClient(eth))
+	b.SetMaxBatch(conf.MaxOpsForBundle)
 	b.UseLogger(logr)
 	if err := b.UserMeter(otel.GetMeterProvider().Meter("bundler")); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Add an optional configuration value `ERC4337_BUNDLER_MAX_OPS_FOR_BATCH`.
It controls the maximum number of UserOps in a bundle transaction, by calling `b.SetMaxBatch()`.
The value defaults to 0 (unlimited).