### PR TITLE
feat: add erc4337_bundler_get_logs_step_size params

### DIFF
--- a/internal/config/values.go
+++ b/internal/config/values.go
@@ -83,6 +83,7 @@ func GetValues() *Values {
 	viper.SetDefault("erc4337_bundler_otel_insecure_mode", false)
 	viper.SetDefault("erc4337_bundler_debug_mode", false)
 	viper.SetDefault("erc4337_bundler_gin_mode", gin.ReleaseMode)
+	viper.SetDefault("erc4337_bundler_get_logs_step_size", 1000)
 
 	// Read in from .env file if available
 	viper.SetConfigName(".env")
@@ -117,6 +118,7 @@ func GetValues() *Values {
 	_ = viper.BindEnv("erc4337_bundler_otel_insecure_mode")
 	_ = viper.BindEnv("erc4337_bundler_debug_mode")
 	_ = viper.BindEnv("erc4337_bundler_gin_mode")
+	_ = viper.BindEnv("erc4337_bundler_get_logs_step_size")
 
 	// Validate required variables
 	if variableNotSetOrIsNil("erc4337_bundler_eth_client_url") {

--- a/internal/config/values.go
+++ b/internal/config/values.go
@@ -83,7 +83,7 @@ func GetValues() *Values {
 	viper.SetDefault("erc4337_bundler_otel_insecure_mode", false)
 	viper.SetDefault("erc4337_bundler_debug_mode", false)
 	viper.SetDefault("erc4337_bundler_gin_mode", gin.ReleaseMode)
-	viper.SetDefault("erc4337_bundler_get_logs_step_size", 1000)
+	viper.SetDefault("erc4337_bundler_get_logs_step_size", 10000)
 
 	// Read in from .env file if available
 	viper.SetConfigName(".env")

--- a/pkg/entrypoint/filter/event.go
+++ b/pkg/entrypoint/filter/event.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"context"
+	"github.com/spf13/viper"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -25,9 +26,10 @@ func filterUserOperationEvent(
 	}
 	toBlk := big.NewInt(0).SetUint64(bn)
 	startBlk := big.NewInt(0)
-	sub10kBlk := big.NewInt(0).Sub(toBlk, big.NewInt(10000))
-	if sub10kBlk.Cmp(startBlk) > 0 {
-		startBlk = sub10kBlk
+	getLogsStepSize := viper.GetInt64("erc4337_bundler_get_logs_step_size")
+	subStepSizeBlk := big.NewInt(0).Sub(toBlk, big.NewInt(getLogsStepSize))
+	if subStepSizeBlk.Cmp(startBlk) > 0 {
+		startBlk = subStepSizeBlk
 	}
 
 	return ep.FilterUserOperationEvent(


### PR DESCRIPTION
Some nodes limit the span of blocks scanned by the `eth_getLogs` function, such as Alchemy's Polygon node, so it is recommended to configure it using parameters.